### PR TITLE
Fitler by attribute set id when the identifier is being checked

### DIFF
--- a/Model/CustomEntity.php
+++ b/Model/CustomEntity.php
@@ -314,7 +314,7 @@ class CustomEntity extends \Smile\ScopedEav\Model\AbstractEntity implements Iden
             ->addFieldToFilter('is_active', 1)
             ->setPageSize(1);
         if ($attributeSetId !== null) {
-            $collection->addFieldToSelect('attribute_set_id', $attributeSetId);
+            $collection->addFieldToFilter('attribute_set_id', $attributeSetId);
         }
         if (!$collection->getSize()) {
             throw NoSuchEntityException::doubleField('url_key', $urlKey, 'attribute_set_id', $attributeSetId);


### PR DESCRIPTION
Without this fix, we have an issue with two custom entities with the same url_key but not the same attribute set id. In this case, we always display the first item found, even if the attribute set is wrong.