### PR TITLE
Added custom entity attribute type to custom entity.

### DIFF
--- a/Block/Adminhtml/Attribute/Edit/Tab/Main.php
+++ b/Block/Adminhtml/Attribute/Edit/Tab/Main.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\CustomEntity\Block\Adminhtml\Attribute\Edit\Tab;
+
+use Magento\Backend\Block\Template\Context;
+use Magento\Backend\Block\Widget\Form\Element\Dependence;
+use Magento\Config\Model\Config\Source\YesnoFactory;
+use Magento\Eav\Block\Adminhtml\Attribute\PropertyLocker;
+use Magento\Eav\Helper\Data;
+use Magento\Eav\Model\Adminhtml\System\Config\Source\InputtypeFactory;
+use Magento\Framework\Data\FormFactory;
+use Magento\Framework\Registry;
+use Smile\CustomEntity\Model\CustomEntity\AttributeSet\Options;
+
+/**
+ * Custom entity attribute edit main form.
+ */
+class Main extends \Smile\ScopedEav\Block\Adminhtml\Attribute\Edit\Tab\Main
+{
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        FormFactory $formFactory,
+        Data $eavData,
+        YesnoFactory $yesnoFactory,
+        InputtypeFactory $inputTypeFactory,
+        PropertyLocker $propertyLocker,
+        protected Options $attributeSetOptions,
+        array $disableScopeChangeList = [],
+        array $data = []
+    ) {
+        parent::__construct(
+            $context,
+            $registry,
+            $formFactory,
+            $eavData,
+            $yesnoFactory,
+            $inputTypeFactory,
+            $propertyLocker,
+            $disableScopeChangeList,
+            $data
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _prepareForm(): self
+    {
+        parent::_prepareForm();
+
+        $form     = $this->getForm();
+        $fieldset = $form->getElement('base_fieldset');
+
+        // Add input to select custom entity type.
+        $fieldset->addField(
+            'custom_entity_attribute_set_id',
+            'select',
+            [
+                'name'  => 'custom_entity_attribute_set_id',
+                'label'  => __('Custom entity type'),
+                'title'  => __('Custom entity type'),
+                'component' => 'Magento_Catalog/js/components/visible-on-option/fieldset',
+                'values' => array_merge(
+                    [['value' => null, 'label' => __('Select...')]],
+                    $this->attributeSetOptions->toOptionArray()
+                ),
+                'visible' => 'false',
+            ],
+            'frontend_input'
+        );
+
+        //Added dependency between 'Custom entity type' and 'Input Type'.
+        $this->setChild(
+            'form_after',
+            $this->getLayout()->createBlock(
+                Dependence::class
+            )->addFieldMap(
+                "frontend_input",
+                'frontend_input_type'
+            )->addFieldMap(
+                "custom_entity_attribute_set_id",
+                'custom_entity_attribute_set_id'
+            )->addFieldDependence(
+                'custom_entity_attribute_set_id',
+                'frontend_input_type',
+                'smile_custom_entity_select'
+            )
+        );
+
+        // Disable 'Custom entity type' input if the attribute is already created.
+        if ($this->getAttributeObject() && $this->getAttributeObject()->getAttributeId()) {
+            $form->getElement('custom_entity_attribute_set_id')->setDisabled(1);
+        }
+
+        return $this;
+    }
+}

--- a/Controller/Adminhtml/Attribute/Save.php
+++ b/Controller/Adminhtml/Attribute/Save.php
@@ -7,7 +7,7 @@ namespace Smile\CustomEntity\Controller\Adminhtml\Attribute;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Controller\Result\ForwardFactory;
 use Magento\Framework\Serialize\Serializer\FormData;
-use Smile\ScopedEav\ViewModel\Data as DataViewModel;
+use Smile\CustomEntity\ViewModel\Attribute\Data as DataViewModel;
 
 /**
  * Custom entity attribute save controller.
@@ -26,10 +26,10 @@ class Save extends \Smile\ScopedEav\Controller\Adminhtml\Attribute\Save
     // @codingStandardsIgnoreLine Override builder attribute (Generic.CodeAnalysis.UselessOverridingMethod.Found)
     public function __construct(
         Context $context,
-        DataViewModel $dataViewModel,
         Builder $attributeBuilder,
-        ?FormData $formDataSerializer,
-        ForwardFactory $resultForwardFactory
+        ForwardFactory $resultForwardFactory,
+        DataViewModel $dataViewModel,
+        ?FormData $formDataSerializer
     ) {
         parent::__construct(
             $context,

--- a/Model/Source/Attribute/CustomEntity.php
+++ b/Model/Source/Attribute/CustomEntity.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\CustomEntity\Model\Source\Attribute;
+
+use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Smile\CustomEntity\Api\CustomEntityRepositoryInterface;
+
+/**
+ * CustomEntity options source model.
+ */
+class CustomEntity extends AbstractSource
+{
+    public function __construct(
+        protected CustomEntityRepositoryInterface $customEntityRepository,
+        protected SearchCriteriaBuilder $searchCriteriaBuilder,
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAllOptions(): array
+    {
+        $customEntityTypeId = $this->getAttribute()->getData('custom_entity_attribute_set_id');
+        if (!$customEntityTypeId) {
+            return [];
+        }
+
+        if ($this->_options === null) {
+            $searchCriteria = $this->searchCriteriaBuilder->addFilter(
+                'attribute_set_id',
+                $customEntityTypeId
+            )->create();
+            $entities = $this->customEntityRepository->getList($searchCriteria);
+            foreach ($entities->getItems() as $entity) {
+                $this->_options[] = ['label' => $entity->getName(), 'value' => $entity->getId()];
+            }
+        }
+
+        return $this->_options;
+    }
+}

--- a/Ui/DataProvider/CustomEntity/Form/Modifier/CustomEntityAttribute.php
+++ b/Ui/DataProvider/CustomEntity/Form/Modifier/CustomEntityAttribute.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\CustomEntity\Ui\DataProvider\CustomEntity\Form\Modifier;
+
+use Smile\ScopedEav\Model\Locator\LocatorInterface;
+use Smile\ScopedEav\Ui\DataProvider\Entity\Form\Modifier\AbstractModifier;
+use Smile\ScopedEav\Ui\DataProvider\Entity\Form\Modifier\Helper\Eav as EavHelper;
+
+class CustomEntityAttribute extends AbstractModifier
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        protected LocatorInterface $locator,
+        protected EavHelper $eavHelper
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Changed custom_entity attribute value type to array.
+     */
+    public function modifyData(array $data): array
+    {
+        if (!$this->locator->getEntity()->getId()) {
+            return $data;
+        }
+
+        $entityId = $this->locator->getEntity()->getId();
+
+        foreach (array_keys($this->getGroups()) as $groupCode) {
+            $attributes = !empty($this->getAttributes()[$groupCode]) ? $this->getAttributes()[$groupCode] : [];
+
+            foreach ($attributes as $attribute) {
+                if (
+                    $attribute->getFrontendInput() == 'smile_custom_entity_select'
+                    && key_exists($attribute->getAttributeCode(), $data[$entityId][self::DATA_SOURCE_DEFAULT])
+                ) {
+                    $value = $data[$entityId][self::DATA_SOURCE_DEFAULT][$attribute->getAttributeCode()];
+                    $data[$entityId][self::DATA_SOURCE_DEFAULT][$attribute->getAttributeCode()] =
+                        $value ? explode(',', $value) : [];
+                }
+            }
+        }
+        return $data;
+    }
+    /**
+     * @inheritdoc
+     *
+     * Added custom_entity field configuration.
+     */
+    public function modifyMeta(array $meta): array
+    {
+        foreach ($meta as $groupCode => $groupConfig) {
+            $meta[$groupCode] = $this->modifyMetaConfig($groupConfig);
+        }
+
+        return $meta;
+    }
+
+    /**
+     * Modification of group config.
+     */
+    protected function modifyMetaConfig(array $metaConfig): array
+    {
+        if (isset($metaConfig['children'])) {
+            foreach ($metaConfig['children'] as $attributeCode => $attributeConfig) {
+                if ($this->startsWith($attributeCode, self::CONTAINER_PREFIX)) {
+                    $metaConfig['children'][$attributeCode] = $this->modifyMetaConfig($attributeConfig);
+                } elseif (
+                    !empty($attributeConfig['arguments']['data']['config']['dataType']) &&
+                    $attributeConfig['arguments']['data']['config']['dataType'] === 'smile_custom_entity_select'
+                ) {
+                    $metaConfig['children'][$attributeCode] = $this->modifyAttributeConfig($attributeConfig);
+                }
+            }
+        }
+
+        return $metaConfig;
+    }
+
+    /**
+     * Modification of attribute config.
+     */
+    protected function modifyAttributeConfig(array $attributeConfig): array
+    {
+        return array_replace_recursive(
+            $attributeConfig,
+            [
+                'arguments' => [
+                    'data' => [
+                        'config' => [
+                            'component'     => 'Magento_Ui/js/form/element/ui-select',
+                            'disableLabel'  => true,
+                            'elementTmpl'   => 'ui/grid/filters/elements/ui-select',
+                            'filterOptions' => true,
+                            'multiple'      => true,
+                            'showCheckbox'  => true,
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * List of attribute groups of the form.
+     */
+    protected function getGroups(): array
+    {
+        return $this->eavHelper->getGroups($this->getAttributeSetId());
+    }
+
+    /**
+     * List of attributes of the form.
+     */
+    protected function getAttributes(): array
+    {
+        return $this->eavHelper->getAttributes($this->locator->getEntity(), $this->getAttributeSetId());
+    }
+
+    /**
+     * Return current attribute set id.
+     */
+    protected function getAttributeSetId(): int
+    {
+        return (int) $this->locator->getEntity()->getAttributeSetId();
+    }
+}

--- a/ViewModel/Attribute/Data.php
+++ b/ViewModel/Attribute/Data.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smile\CustomEntity\ViewModel\Attribute;
+
+use Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend;
+use Smile\CustomEntity\Model\Source\Attribute\CustomEntity as CustomEntitySource;
+
+/**
+ * CustomEntity EAV view model.
+ */
+class Data extends \Smile\ScopedEav\ViewModel\Data
+{
+    /**
+     * @inheritDoc
+     */
+    public function getAttributeSourceModelByInputType(string $inputType): ?string
+    {
+        return match ($inputType) {
+            'smile_custom_entity_select' => CustomEntitySource::class,
+            default => parent::getAttributeSourceModelByInputType($inputType),
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAttributeBackendModelByInputType(string $inputType): ?string
+    {
+        return match ($inputType) {
+            'smile_custom_entity_select' => ArrayBackend::class,
+            default => parent::getAttributeBackendModelByInputType($inputType),
+        };
+    }
+
+    /**
+     * Detect backend storage type using frontend input type.
+     */
+    public function getAttributeBackendTypeByInput(string $inputType): ?string
+    {
+        return match ($inputType) {
+            'smile_custom_entity_select' => 'varchar',
+            default => parent::getAttributeBackendTypeByInput($inputType),
+        };
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -22,6 +22,10 @@
                     <item name="class" xsi:type="string">Smile\ScopedEav\Ui\DataProvider\Entity\Form\Modifier\System</item>
                     <item name="sortOrder" xsi:type="number">30</item>
                 </item>
+                <item name="custom_entity_attribute" xsi:type="array">
+                    <item name="class" xsi:type="string">Smile\CustomEntity\Ui\DataProvider\CustomEntity\Form\Modifier\CustomEntityAttribute</item>
+                    <item name="sortOrder" xsi:type="number">40</item>
+                </item>
             </argument>
         </arguments>
     </virtualType>
@@ -61,18 +65,37 @@
             <argument name="entityBuilder" xsi:type="object">Smile\CustomEntity\Controller\Adminhtml\Entity\Builder</argument>
         </arguments>
     </type>
-
     <type name="Smile\CustomEntity\Controller\Adminhtml\Entity\Save">
         <arguments>
             <argument name="entityBuilder" xsi:type="object">Smile\CustomEntity\Controller\Adminhtml\Entity\Builder</argument>
         </arguments>
     </type>
-
     <type name="Magento\Ui\DataProvider\Mapper\FormElement">
         <arguments>
             <argument name="mappings" xsi:type="array">
                 <item name="smile_custom_entity" xsi:type="string">input</item>
+                <item name="smile_custom_entity_select" xsi:type="string">input</item>
             </argument>
+        </arguments>
+    </type>
+    <virtualType name="Smile\CustomEntity\Model\Adminhtml\System\Config\Source\Inputtype" type="Smile\ScopedEav\Model\Adminhtml\System\Config\Source\Inputtype">
+        <arguments>
+            <argument name="optionsArray" xsi:type="array">
+                <item name="900" xsi:type="array">
+                    <item name="value" xsi:type="string">smile_custom_entity_select</item>
+                    <item name="label" xsi:type="string" translate="true">Сustom entity</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Smile\CustomEntity\Model\Adminhtml\System\Config\Source\InputtypeFactory" type="Smile\ScopedEav\Model\Adminhtml\System\Config\Source\InputtypeFactory">
+        <arguments>
+            <argument name="instanceName" xsi:type="string">Smile\CustomEntity\Model\Adminhtml\System\Config\Source\Inputtype</argument>
+        </arguments>
+    </virtualType>
+    <type name="Smile\CustomEntity\Block\Adminhtml\Attribute\Edit\Tab\Main">
+        <arguments>
+            <argument name="inputTypeFactory" xsi:type="object">Smile\CustomEntity\Model\Adminhtml\System\Config\Source\InputtypeFactory</argument>
         </arguments>
     </type>
 

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -156,8 +156,8 @@
       <column name="website_id"/>
     </index>
   </table>
-  <table name="catalog_eav_attribute" resource="default">
-    <column xsi:type="smallint" name="custom_entity_attribute_set_id" padding="5" unsigned="true" nullable="true" identity="false" comment="Additional swatch attributes data"/>
-    <constraint xsi:type="foreign" referenceId="CAT_EAV_ATTR_CUSTOM_ENTT_ATTR_SET_ID_EAV_ATTR_SET_ATTR_SET_ID" table="catalog_eav_attribute" column="custom_entity_attribute_set_id" referenceTable="eav_attribute_set" referenceColumn="attribute_set_id" onDelete="CASCADE"/>
-  </table>
+    <table name="eav_attribute" resource="default">
+        <column xsi:type="smallint" name="custom_entity_attribute_set_id" padding="5" unsigned="true" nullable="true" identity="false" comment="Custom entity type id"/>
+        <constraint xsi:type="foreign" referenceId="EAV_ATTR_CUSTOM_ENTT_ATTR_SET_ID_EAV_ATTR_SET_ATTR_SET_ID" table="eav_attribute" column="custom_entity_attribute_set_id" referenceTable="eav_attribute_set" referenceColumn="attribute_set_id" onDelete="CASCADE"/>
+    </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -4,7 +4,8 @@
             "attribute_id": true,
             "is_global": true,
             "is_wysiwyg_enabled": true,
-            "is_html_allowed_on_front": true
+            "is_html_allowed_on_front": true,
+            "custom_entity_attribute_set_id": true
         },
         "constraint": {
             "PRIMARY": true,
@@ -140,12 +141,12 @@
             "SMILE_CUSTOM_ENTT_WS_ENTT_ID_SMILE_CUSTOM_ENTT_ENTT_ID": true
         }
     },
-    "catalog_eav_attribute": {
+    "eav_attribute": {
         "column": {
             "custom_entity_attribute_set_id": true
         },
         "constraint": {
-            "CAT_EAV_ATTR_CUSTOM_ENTT_ATTR_SET_ID_EAV_ATTR_SET_ATTR_SET_ID": true
+            "EAV_ATTR_CUSTOM_ENTT_ATTR_SET_ID_EAV_ATTR_SET_ATTR_SET_ID": true
         }
     }
 }

--- a/view/adminhtml/layout/custom_entity_attribute_edit.xml
+++ b/view/adminhtml/layout/custom_entity_attribute_edit.xml
@@ -10,7 +10,8 @@
     <body>
         <referenceContainer name="main">
             <!-- Append custom entity specifics fields. -->
-            <block class="Smile\CustomEntity\Block\Adminhtml\Attribute\Edit\Tab\Front" as="front" />
+            <block class="Smile\CustomEntity\Block\Adminhtml\Attribute\Edit\Tab\Front" name="main.front" />
+            <referenceBlock name="main.base" class="Smile\CustomEntity\Block\Adminhtml\Attribute\Edit\Tab\Main"/>
         </referenceContainer>
     </body>
 


### PR DESCRIPTION
Add a new custom entity attribute type for custom entity attributes to be able to create relationships between custom entities.

Added input Types:
custom entity select

When selecting a custom entity input type, a 'Custom entity type' input appears for the ability to choose which custom entity type will be used for this attribute


`Block/Adminhtml/Attribute/Edit/Tab/Main.php`

Attribute edit main form block.
Added 'Custom entity type' (custom_entity_attribute_set_id) input and dependency between 'Custom entity type' and 'Input Type' - show 'Custom entity type'  input when 'smile_custom_entity_select' option selected in 'Input Type'.

`Controller/Adminhtml/Attribute/Save.php`

Changed dataViewModel instance to be able to add the new 'backend_type' and 'source_model' types to the attribute.

 
`Model/Adminhtml/System/Config/Source/Inputtype.php`

Created to be able to add new input types for the "custom entity" attribute only.

 
`Model/Source/Attribute/CustomEntity.php`

Source model for options. 
Return custom entities filtered by the entity type stored in the attribute's custom_entity_attribute_set_id parameter

 
`ViewModel/Attribute/Data.php`

overwrite getAttributeSourceModelByInputType() - added source model for 'smile_custom_entity_select' input type.

owerwrite getAttributeBackendModelByInputType() - added backend model for 'smile_custom_entity_select' input type

added  getBackendTypeByInput() - added 'smile_custom_entity_select' input type detecting.
 
`etc/db_schema.xml`

added "custom_entity_attribute_set_id" for saving custom entity type if attribute is 'smile_custom_entity_select'  type. 
    
 
`view/adminhtml/layout/custom_entity_attribute_edit.xml`

Changed block for main form to be able to modify form fields.

 
`etc/adminhtml/di.xml`
    
Added 'smile_custom_entity_select' input type  to Inputtype Source list.
Added custom entity edit form modifier.

`Ui\DataProvider\CustomEntity\Form\Modifier\CustomEntityAttribute`
modifyData - changed values ​​for attributes of type `custom_entity_select` to array to display correctly in input
modifyMeta - added additional configuration for custom_entity_select input component