### PR TITLE
Change cache_tag: smile_custom_entity -> sce and smile_custom_entity_set -> sces

### DIFF
--- a/Model/CustomEntity.php
+++ b/Model/CustomEntity.php
@@ -32,9 +32,9 @@ class CustomEntity extends AbstractEntity implements IdentityInterface, CustomEn
     /**
      * Product cache tag
      */
-    public const CACHE_TAG = 'smile_custom_entity';
+    public const CACHE_TAG = 'sce';
 
-    public const CACHE_CUSTOM_ENTITY_SET_TAG = 'smile_custom_entity_set';
+    public const CACHE_CUSTOM_ENTITY_SET_TAG = 'sces';
 
     /**
      * @inheritdoc


### PR DESCRIPTION
For fix issue https://github.com/Smile-SA/magento2-module-custom-entity-product-link/issues/45
Reducing the number of cache_tag characters allows you to have more cache_tags in the page header.